### PR TITLE
ci: add GitHub Actions workflow for formatting and linting checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,11 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        check-task: [format:check, lint]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -17,8 +20,4 @@ jobs:
           cache: npm
       - run: npm ci
 
-      - name: Check formatting
-        run: npm run format:check
-
-      - name: Run lint
-        run: npm run lint
+      - run: npm run ${{ matrix.check-task }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+      - run: npm ci
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Run lint
+        run: npm run lint

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "scripts": {
     "build": "tsc",
     "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "prepare": "npm run build"


### PR DESCRIPTION
### Summary

Add a GitHub Actions workflow that runs formatting and linting checks on each push and pull request to the `main` branch.

### Details

- Runs `npm run format:check` to verify code formatting
- Runs `npm run lint` to enforce linting rules